### PR TITLE
Curvature drive hotfix

### DIFF
--- a/Alfredo_NoU2.cpp
+++ b/Alfredo_NoU2.cpp
@@ -238,8 +238,10 @@ void NoU_Drivetrain::arcadeDrive(float throttle, float rotation, boolean inverte
 void NoU_Drivetrain::curvatureDrive(float throttle, float rotation, boolean isQuickTurn, boolean invertedReverse) {
     throttle = applyInputCurve(throttle);
     rotation = applyInputCurve(rotation);
+
     float angularPower;
     boolean overPower;
+
     if (isQuickTurn) {
         if (fabs(throttle) < quickStopThreshold) {
             quickStopAccumulator = (1 - quickStopAlpha) * quickStopAccumulator + quickStopAlpha * rotation * 2;
@@ -250,11 +252,11 @@ void NoU_Drivetrain::curvatureDrive(float throttle, float rotation, boolean isQu
     else {
         overPower = false;
         angularPower = fabs(throttle) * rotation - quickStopAccumulator;
-    }
 
-    if (quickStopAccumulator > 1) quickStopAccumulator--;
-    else if (quickStopAccumulator < -1) quickStopAccumulator++;
-    else quickStopAccumulator = 0;
+        if (quickStopAccumulator > 1) quickStopAccumulator--;
+        else if (quickStopAccumulator < -1) quickStopAccumulator++;
+        else quickStopAccumulator = 0;
+    }
 
     float leftPower;
     float rightPower;
@@ -265,11 +267,6 @@ void NoU_Drivetrain::curvatureDrive(float throttle, float rotation, boolean isQu
     else {
         leftPower = throttle + angularPower;
         rightPower = throttle - angularPower;
-    }
-
-    if (throttle < 0 && invertedReverse) {
-        leftPower = -leftPower;
-        rightPower = -rightPower;
     }
 
     if (overPower) {

--- a/Alfredo_NoU2.cpp
+++ b/Alfredo_NoU2.cpp
@@ -235,7 +235,7 @@ void NoU_Drivetrain::arcadeDrive(float throttle, float rotation, boolean inverte
     setMotors(leftPower, rightPower, leftPower, rightPower);
 }
 
-void NoU_Drivetrain::curvatureDrive(float throttle, float rotation, boolean isQuickTurn, boolean invertedReverse) {
+void NoU_Drivetrain::curvatureDrive(float throttle, float rotation, boolean isQuickTurn) {
     throttle = applyInputCurve(throttle);
     rotation = applyInputCurve(rotation);
 
@@ -260,14 +260,9 @@ void NoU_Drivetrain::curvatureDrive(float throttle, float rotation, boolean isQu
 
     float leftPower;
     float rightPower;
-    if (throttle < 0 && invertedReverse) {
-        leftPower = throttle - angularPower;
-        rightPower = throttle + angularPower;
-    }
-    else {
-        leftPower = throttle + angularPower;
-        rightPower = throttle - angularPower;
-    }
+
+    leftPower = throttle + angularPower;
+    rightPower = throttle - angularPower;
 
     if (overPower) {
         if (leftPower > 1) {

--- a/Alfredo_NoU2.h
+++ b/Alfredo_NoU2.h
@@ -112,7 +112,7 @@ class NoU_Drivetrain {
                         NoU_Motor* rearLeftMotor, NoU_Motor* rearRightMotor);
         void tankDrive(float leftPower, float rightPower);
         void arcadeDrive(float throttle, float rotation, boolean invertedReverse = false);
-        void curvatureDrive(float throttle, float rotation, boolean isQuickTurn);
+        void curvatureDrive(float throttle, float rotation, boolean isQuickTurn = true);
         void holonomicDrive(float xVelocity, float yVelocity, float rotation);
         void setMinimumOutput(float minimumOutput);
         void setMaximumOutput(float maximumOutput);

--- a/Alfredo_NoU2.h
+++ b/Alfredo_NoU2.h
@@ -112,7 +112,7 @@ class NoU_Drivetrain {
                         NoU_Motor* rearLeftMotor, NoU_Motor* rearRightMotor);
         void tankDrive(float leftPower, float rightPower);
         void arcadeDrive(float throttle, float rotation, boolean invertedReverse = false);
-        void curvatureDrive(float throttle, float rotation, boolean isQuickTurn, boolean invertedReverse = false);
+        void curvatureDrive(float throttle, float rotation, boolean isQuickTurn);
         void holonomicDrive(float xVelocity, float yVelocity, float rotation);
         void setMinimumOutput(float minimumOutput);
         void setMaximumOutput(float maximumOutput);

--- a/examples/NoU2CurvatureBot/NoU2CurvatureBot.ino
+++ b/examples/NoU2CurvatureBot/NoU2CurvatureBot.ino
@@ -34,12 +34,7 @@ void loop() {
         }
     }
     servo.write((servoAxis + 1) * 90);
-    if (fabs(throttle) < 0.2) {
-        drivetrain.curvatureDrive(throttle, rotation, true);
-    }
-    else {
-        drivetrain.curvatureDrive(throttle, rotation, false);
-    }
+    drivetrain.curvatureDrive(throttle, rotation);
 
     // RSL logic
     if (millis() - lastTimePacketReceived > 1000) {


### PR DESCRIPTION
Changed curvature drive to align with WPILib's [DifferentialDrive](https://github.com/wpilibsuite/allwpilib/blob/main/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java) implementation. There was previously a small problem that caused turning logic while driving in reverse to be slightly different than while driving forward.