### PR TITLE
Rewrite tutorials in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once the top of the console says `Done uploading.`, the example is on the ESP32 
 
 ### Driving a robot
 
-[AlfredoConnect](https://github.com/AlfredoElectronics/AlfredoConnect-Desktop/releases) is a driver station that runs on Windows for controlling robots over Bluetooth using your computer's keyboard or connected gamepads. It has a corresponding Arduino library, [AlfredoConnect-Receive](https://github.com/AlfredoElectronics/AlfredoConnect-Receive), which contains examples for using AlfredoConnect with the Alfredo NoU2.
+[AlfredoConnect](https://github.com/AlfredoElectronics/AlfredoConnect-Desktop/releases) is a driver station that runs on Windows for controlling robots over Bluetooth using your computer's keyboard or connected gamepads. It has a corresponding Arduino library, [AlfredoConnect-Receive](https://github.com/AlfredoElectronics/AlfredoConnect-Receive), which contains examples for using AlfredoConnect with the Alfredo NoU2. After following the [basic setup tutorial](#basic-setup) here, follow the [getting started tutorials for AlfredoConnect-Receive](https://github.com/AlfredoElectronics/AlfredoConnect-Receive#getting-started) to learn how to control your robot using AlfredoConnect.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -7,55 +7,40 @@ Library for the Alfredo NoU v2.6. Supports motors and servos and has helper meth
 
 ## Getting started
 
-**NOTE**: This tutorial still references the [old driver station](https://github.com/ddthj/MiniFRC), which is now outdated. Check out [AlfredoConnect](https://github.com/AlfredoElectronics/AlfredoConnect-Desktop) for an up-to-date driver station.
-
-This tutorial should help you set up a Windows computer to control a robot that uses an ESP32 and Alfredo NoU2 control system. This setup has been done on Mac before, but a lot of this tutorial won't apply, and it's not recommended unless you really know what you're doing. This tutorial uses the [Arduino IDE](https://www.arduino.cc/en/main/software). You'll need to download and install it if you don't already have it.
-
 ### Basic setup
 
-1. Configure the Arduino IDE to upload to an ESP32. Check out [this board configuration tutorial](https://randomnerdtutorials.com/installing-the-esp32-board-in-arduino-ide-windows-instructions/) for instructions on how to do that.
+This tutorial will guide you through uploading example code to your ESP32 with an attached Alfredo NoU2. This should work on any OS.
 
-2. Download this repository as a ZIP. Click the green button on this page that says `Clone or download`, then `Download ZIP`.
+1. **Get the Arduino IDE**. If you don't already have it, download it from the [Arduino website](https://www.arduino.cc/en/main/software) and install it.
 
-3. Add this library to the Arduino IDE. In the Arduino IDE, Click `Sketch` > `Include Library` > `Add .ZIP Library...`, and select the ZIP file you downloaded.
+2. **Configure the Arduino IDE to upload to an ESP32.** Check out [this board configuration tutorial](https://randomnerdtutorials.com/installing-the-esp32-board-in-arduino-ide-windows-instructions/) for instructions on how to do that.
 
-4. Connect your ESP32 and select the COM port. Connect your ESP32 to your computer using a micro USB cable. In the Arduino IDE, select the corresponding COM port under `Tools` > `Port`. The correct COM port may say `(Silicon Labs)` next to it. If none of them do, you can unplug and replug the USB to see which COM port disappears and reappears.
+3. **Download this repository as a ZIP**. Click [here](https://github.com/AlfredoElectronics/Alfredo-NoU2/archive/refs/heads/master.zip) to start the download, or click the green button on this page that says `Code`, then `Download ZIP`.
 
-5. Make sure you have the right board selected. In the Arduino IDE, go to `Tools` > `Board` > `ESP32 Arduino` (if you don't see this, make sure you completed step 1) and select `ESP32 Dev Module`.
+4. **Add this library to the Arduino IDE**. In the Arduino IDE, Click `Sketch` > `Include Library` > `Add .ZIP Library...`, and select the ZIP file you downloaded.
 
-6. Open the `NoU2MotorParty` example. In the Arduino IDE, go to `File` > `Examples` > `Alfredo-NoU2` (you might need to scroll down) and select `NoU2MotorParty`. This will open a new window with the example opened. You can close the old one.
+5. **Open the `NoU2MotorParty` example**. In the Arduino IDE, go to `File` > `Examples` > `Alfredo-NoU2` (you might need to scroll down) and select `NoU2MotorParty`. This will open a new window with the example opened. You can close the old one.
 
-7. Upload `NoU2MotorParty` to your ESP32. In the window with `NoU2MotorParty` opened, click the upload button (the arrow in the top left). When the console on the bottom of the window starts showing `Connecting....._____.....`, hold down the `BOOT` button on the ESP32.
+6. **Connect your ESP32 and select the COM port**. Connect your ESP32 to your computer using a micro USB cable. In the Arduino IDE, select the corresponding COM port under `Tools` > `Port`. The correct COM port may say `(Silicon Labs)` next to it. If none of them do, you can unplug and replug the USB to see which COM port disappears and reappears.
 
-Once the top of the console says `Done uploading.`, the example is on the ESP32 and you can unplug it from the computer. When connected to an Alfredo NoU2, the `NoU2MotorParty` example we uploaded will pulse any connected motors and servos back and forth.
+7. **Select ESP32 as the board type**. In the Arduino IDE, go to `Tools` > `Board` > `ESP32 Arduino` and select `ESP32 Dev Module`. On older versions of Arduino, it may just be `Tools` > `Board` > `ESP32 Dev Module`.
+
+8. **Upload `NoU2MotorParty` to your ESP32**. In the window with `NoU2MotorParty` opened, click the upload button (the arrow in the top left). When the console on the bottom of the window starts showing `Connecting....._____.....`, hold down the `BOOT` button on the ESP32.
+
+Once the top of the console says `Done uploading.`, the example is on the ESP32 and you can unplug it from the computer. When connected to an Alfredo NoU2, the `NoU2MotorParty` example will pulse any connected motors and servos back and forth.
 
 ### Driving a robot
 
-5. Once you've tested out the motor party code, open up the code for a robot, like any of the sketches in `examples` that end with "Bot". Before you upload to your ESP32, edit the code make sure to configure the name that the Bluetooth connection will appear as when pairing with the ESP32. In the examples, the default name is "DefaultBot", and you should change it to your own name by editing the line `bluetooth.begin("DefaultBot")` to something like `bluetooth.begin("My Cool Robot")`. Now's a good time to do this because, if you wait until later to change it, you'll have to restart your computer to be able to pair with the ESP32 under the new name.
-
-6. To start driving your robot, either with your own code or one of the robot examples, start by pairing a computer with the ESP32 over Bluetooth. On Windows 10, you can pair with a Bluetooth device by going to your **Bluetooth & other devices** settings page > **Add Bluetooth or other device** > **Bluetooth**. All of the robot examples have the ESP32 advertise its Bluetooth connection as "DefaultBot", although you should have changed it in step 4 to your own name. It shouldn't ask for a passcode to pair, but if it does, the default is typically "1234".
-
-7. Once you've paired a computer and the ESP32, you'll need to find out what COM port you need to use to send information to the ESP32 from the computer. On Windows 10, open up your Bluetooth settings (the "Bluetooth & other devices" page) and click "More Bluetooth options" in the "Related settings" on the right. Click on the "COM Ports" tab and you should see a pair of COM ports, both with the same name as the Bluetooth device you paired with ("DefaultBot" for the examples). Note the number of the port with the Direction "Outgoing". This is the COM port we'll use to send information to the robot.
-
-8. Download the [MiniFRC Driver Station](https://github.com/ddthj/MiniFRC). If you're using a robot example from this repository, swap in the `config.txt` file from the example folder. In the `config.txt` file, you'll need to change the COM port to the one you found earlier. You can look at the comments in the original [`config.txt`](https://github.com/ddthj/MiniFRC/blob/master/config.txt) file in the Driver Station repository for instructions on how to modify axes, add buttons, and receive input from connected joysticks or game controllers.
-
-9. Boot up the Driver Station (using the [`DriverStation.exe`](https://github.com/ddthj/MiniFRC/blob/master/DriverStation.exe) file). The Driver Station should connect to the robot, and you should be able to control it using the keybinds assigned in the `config.txt` file.
+[AlfredoConnect](https://github.com/AlfredoElectronics/AlfredoConnect-Desktop/releases) is a driver station that runs on Windows for controlling robots over Bluetooth using your computer's keyboard or connected gamepads. It has a corresponding Arduino library, [AlfredoConnect-Receive](https://github.com/AlfredoElectronics/AlfredoConnect-Receive), which contains examples for using AlfredoConnect with the Alfredo NoU2.
 
 ## Troubleshooting
 
-If the Driver Station doesn't connect to the robot:
-* Make sure the ESP32 is on.
-* Make sure a program that broadcasts Bluetooth is uploaded to the ESP32. All the examples in this repository that end with "Bot" broadcast Bluetooth.
-* Make sure the computer is paired with the ESP32 over Bluetooth.
-* In the same folder as the `DriverStation.exe` file you opened to start the Driver Station, there should be a file called `config.txt`. Make sure the line that says `COM = <port>`, where <port> is a  Change this to the same COM port as you found in step 7s. If the COM port was COM6, you would edit the line to say `COM = COM6`.
+### Can't connect to the ESP32 over USB to upload
+* The most common cause of this is accidentally using a power-only micro USB cable, which won't allow the computer and ESP32 to communicate, but will power on the ESP32. Try a new cable. When plugging in the ESP32, you should hear a sound on the computer indicating it's plugged in.
+* Make sure you're selecting the right COM port. The most common way to check is to unplug the ESP32, check the ports list in the Arduino IDE, (`Tools` > `Port`), plug the ESP32 in, and then check the list again to see what COM port got added. On Windows, you can also open Device Manager (`Win+R`, type in `devmgmt.msc`) and check the `Ports (COM & LPT)` dropdown, which should include a port list similar to the one in the Arduino IDE.
 
-If the Driver Station connects to the robot but the robot won't move:
-* Make sure the line `BAUD = <number>` in the `config.txt` file matches the baud rate you've configured for your robot. By default, the examples are configured for 9600. If you're not sure what the baud rate set by your code is, it's probably 9600. For a baud rate of 9600, this line would say `BAUD = 9600`.
-* Make sure your motors are connected to the same motor port as indicated in the code. The line `NoU_Motor frontLeftMotor(1);` says that there's a motor named `frontLeftMotor` on port 1, so you should make sure a motor is plugged into the terminals labelled M1- and M1+ on the NoU2.
-* Check your `config.txt` file to make sure that you're assigning axes and buttons as you expect. The original [`config.txt`](https://github.com/ddthj/MiniFRC/blob/master/config.txt) file from the Driver Station repository has examples of how this is done. You should see the rendered axes and buttons on the Driver Station change when you move the axes or press buttons. You can test out buttons and axes without a robot by changing your COM port assignment in your `config.txt` file to say `COM = test`.
+## Links
 
-If Driver Station connects and the robot moves, but doesn't move as you expect:
-* Make sure the order you assign buttons and axes corresponds to the order you read them in your code.
-* If one of your motors always runs in reverse, you can set it as inverted in the code by calling `motor.setInverted(true)` in your `setup` function. The robot examples demonstrate this.
-
-Most importantly, when you can't figure something out, ask for help! No one is born good at this stuff, and it takes some time to learn. Take your time to compose a question along with all the relevant information that might help others figure out your problem. MiniFRC participants, asking your question in the [MiniFRC Discord](https://discord.gg/VtGvf6B) is a great way to both get your question answered and meet lots of cool people eager to help you out. We're on the Discord to help out anyone with questions, but opening an issue on our [Issue Tracker](https://github.com/AlfredoElectronics/Alfredo-NoU-2/issues) with the "help wanted" or "question" labels is another good way to bring attention to a well-documented, persistent, or common problem, along with any solutions or workarounds people have found.
+* [**Product Page**](https://alfredoelectronics.github.io/products/alfredo-nou2/): Purchase an Alfredo NoU2 here.
+* [**MiniFRC Discord**](https://discord.gg/VtGvf6B): This is the best place to get quick help with the Alfredo NoU2 and this library from both users and the Alfredo Electronics team.
+* [**Issue Tracker**](https://github.com/AlfredoElectronics/Alfredo-NoU-2/issues): If you're having a problem or need guidance, feel free to open an issue with the `help wanted` or `question` label.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,25 @@ Library for the Alfredo NoU v2.6. Supports motors and servos and has helper meth
 
 This tutorial should help you set up a Windows computer to control a robot that uses an ESP32 and Alfredo NoU2 control system. This setup has been done on Mac before, but a lot of this tutorial won't apply, and it's not recommended unless you really know what you're doing. This tutorial uses the [Arduino IDE](https://www.arduino.cc/en/main/software). You'll need to download and install it if you don't already have it.
 
-1. Firstly, we'll need to configure the Arduino IDE to upload to an ESP32. Check out [this board configuration tutorial](https://randomnerdtutorials.com/installing-the-esp32-board-in-arduino-ide-windows-instructions/) for instructions on how to do that.
+### Basic setup
 
-2. Download this repository as a ZIP by clicking the green button on the right that says **Clone or download**, then **Download ZIP**.
+1. Configure the Arduino IDE to upload to an ESP32. Check out [this board configuration tutorial](https://randomnerdtutorials.com/installing-the-esp32-board-in-arduino-ide-windows-instructions/) for instructions on how to do that.
 
-3. In the Arduino IDE, add this repository as a library by clicking **Sketch** > **Include Library** > **Add .ZIP Library...**, and selecting the ZIP file you downloaded.
+2. Download this repository as a ZIP. Click the green button on this page that says `Clone or download`, then `Download ZIP`.
 
-4. Make sure you've selected the right COM port and board (following the [board configuration tutorial](https://randomnerdtutorials.com/installing-the-esp32-board-in-arduino-ide-windows-instructions/) above) and upload one of the files in the `examples` folder to an ESP32 mounted on a NoU2. A good first test that doesn't require Bluetooth or the Driver Station is `NoU2MotorParty.ino`, which pulses all the connected motors and servos.
+3. Add this library to the Arduino IDE. In the Arduino IDE, Click `Sketch` > `Include Library` > `Add .ZIP Library...`, and select the ZIP file you downloaded.
+
+4. Connect your ESP32 and select the COM port. Connect your ESP32 to your computer using a micro USB cable. In the Arduino IDE, select the corresponding COM port under `Tools` > `Port`. The correct COM port may say `(Silicon Labs)` next to it. If none of them do, you can unplug and replug the USB to see which COM port disappears and reappears.
+
+5. Make sure you have the right board selected. In the Arduino IDE, go to `Tools` > `Board` > `ESP32 Arduino` (if you don't see this, make sure you completed step 1) and select `ESP32 Dev Module`.
+
+6. Open the `NoU2MotorParty` example. In the Arduino IDE, go to `File` > `Examples` > `Alfredo-NoU2` (you might need to scroll down) and select `NoU2MotorParty`. This will open a new window with the example opened. You can close the old one.
+
+7. Upload `NoU2MotorParty` to your ESP32. In the window with `NoU2MotorParty` opened, click the upload button (the arrow in the top left). When the console on the bottom of the window starts showing `Connecting....._____.....`, hold down the `BOOT` button on the ESP32.
+
+Once the top of the console says `Done uploading.`, the example is on the ESP32 and you can unplug it from the computer. When connected to an Alfredo NoU2, the `NoU2MotorParty` example we uploaded will pulse any connected motors and servos back and forth.
+
+### Driving a robot
 
 5. Once you've tested out the motor party code, open up the code for a robot, like any of the sketches in `examples` that end with "Bot". Before you upload to your ESP32, edit the code make sure to configure the name that the Bluetooth connection will appear as when pairing with the ESP32. In the examples, the default name is "DefaultBot", and you should change it to your own name by editing the line `bluetooth.begin("DefaultBot")` to something like `bluetooth.begin("My Cool Robot")`. Now's a good time to do this because, if you wait until later to change it, you'll have to restart your computer to be able to pair with the ESP32 under the new name.
 

--- a/examples/NoU2ArcadeBot/NoU2ArcadeBot.ino
+++ b/examples/NoU2ArcadeBot/NoU2ArcadeBot.ino
@@ -1,3 +1,10 @@
+/**
+ * This example is for the legacy MiniFRC driver station, found here:
+ * https://github.com/ddthj/MiniFRC. To use the AlfredoConnect driver station, check
+ * out AlfredoConnect-Receive, which includes examples for the Alfredo NoU2:
+ * https://github.com/AlfredoElectronics/AlfredoConnect-Receive.
+ */
+
 #include <BluetoothSerial.h>
 #include <Alfredo_NoU2.h>
 

--- a/examples/NoU2CurvatureBot/NoU2CurvatureBot.ino
+++ b/examples/NoU2CurvatureBot/NoU2CurvatureBot.ino
@@ -1,3 +1,10 @@
+/**
+ * This example is for the legacy MiniFRC driver station, found here:
+ * https://github.com/ddthj/MiniFRC. To use the AlfredoConnect driver station, check
+ * out AlfredoConnect-Receive, which includes examples for the Alfredo NoU2:
+ * https://github.com/AlfredoElectronics/AlfredoConnect-Receive.
+ */
+
 #include <BluetoothSerial.h>
 #include <Alfredo_NoU2.h>
 

--- a/examples/NoU2HolonomicBot/NoU2HolonomicBot.ino
+++ b/examples/NoU2HolonomicBot/NoU2HolonomicBot.ino
@@ -1,3 +1,10 @@
+/**
+ * This example is for the legacy MiniFRC driver station, found here:
+ * https://github.com/ddthj/MiniFRC. To use the AlfredoConnect driver station, check
+ * out AlfredoConnect-Receive, which includes examples for the Alfredo NoU2:
+ * https://github.com/AlfredoElectronics/AlfredoConnect-Receive.
+ */
+
 #include <BluetoothSerial.h>
 #include <Alfredo_NoU2.h>
 

--- a/examples/NoU2TankBot/NoU2TankBot.ino
+++ b/examples/NoU2TankBot/NoU2TankBot.ino
@@ -1,3 +1,10 @@
+/**
+ * This example is for the legacy MiniFRC driver station, found here:
+ * https://github.com/ddthj/MiniFRC. To use the AlfredoConnect driver station, check
+ * out AlfredoConnect-Receive, which includes examples for the Alfredo NoU2:
+ * https://github.com/AlfredoElectronics/AlfredoConnect-Receive.
+ */
+
 #include <BluetoothSerial.h>
 #include <Alfredo_NoU2.h>
 


### PR DESCRIPTION
Cleaned up the tutorial up through uploading motor party. Removed the steps for controlling a robot over Bluetooth, instead deferring to the AlfredoConnect-Receive README.