### PR TITLE
Fix servo nonresponse on ESP version >= 3.x

### DIFF
--- a/Alfredo_NoU2.cpp
+++ b/Alfredo_NoU2.cpp
@@ -83,16 +83,16 @@ void NoU_Motor::setState(uint8_t state) {
 	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
       	switch (state) {
 			case FORWARD:	
-				ledcAttach(aPin, MOTOR_PWM_FREQ, MOTOR_PWM_RES);
+				ledcAttachChannel(aPin, MOTOR_PWM_FREQ, MOTOR_PWM_RES, channel);
 				ledcDetach(bPin);
 				break;
 			case BACKWARD:
 				ledcDetach(aPin);
-				ledcAttach(bPin, MOTOR_PWM_FREQ, MOTOR_PWM_RES);
+				ledcAttachChannel(bPin, MOTOR_PWM_FREQ, MOTOR_PWM_RES, channel);
 				break;
 			case BRAKE:
-				ledcAttach(aPin, MOTOR_PWM_FREQ, MOTOR_PWM_RES);
-				ledcAttach(bPin, MOTOR_PWM_FREQ, MOTOR_PWM_RES);
+				ledcAttachChannel(aPin, MOTOR_PWM_FREQ, MOTOR_PWM_RES, channel);
+				ledcAttachChannel(bPin, MOTOR_PWM_FREQ, MOTOR_PWM_RES, channel);
 				break;
 			case RELEASE:
 				ledcDetach(aPin);
@@ -385,7 +385,7 @@ void NoU_Drivetrain::setInputDeadband(float inputDeadband) {
 
 void RSL::initialize() {
 	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-		ledcAttach(RSL_PIN, RSL_PWM_FREQ, RSL_PWM_RES);
+		ledcAttachChannel(RSL_PIN, RSL_PWM_FREQ, RSL_PWM_RES, RSL_CHANNEL);
 	#else
 		ledcSetup(RSL_CHANNEL, RSL_PWM_FREQ, RSL_PWM_RES);
 		ledcAttachPin(RSL_PIN, RSL_CHANNEL);

--- a/Alfredo_NoU2.cpp
+++ b/Alfredo_NoU2.cpp
@@ -192,7 +192,7 @@ NoU_Servo::NoU_Servo(uint8_t servoPort, uint16_t minPulse, uint16_t maxPulse) {
     this->maxPulse = maxPulse;
 	
 	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-		ledcAttach(pin, SERVO_PWM_FREQ, SERVO_PWM_RES);
+		ledcAttachChannel(pin, SERVO_PWM_FREQ, SERVO_PWM_RES, channel);
     #else
 		ledcSetup(channel, SERVO_PWM_FREQ, SERVO_PWM_RES);
 		ledcAttachPin(pin, channel);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Alfredo-NoU2
-version=2.0.6
+version=2.0.7
 author=Alfredo Systems
 maintainer=Jacob Williams (jrw4561@gmail.com)
 sentence=Library for the Alfredo NoU2 robot control board.


### PR DESCRIPTION
Fixes bug where servos don't respond to `write()` commands, when esp32 board core version is 3.0 or later.

This is due to how `ledcAttach()` selects channels "automatically" - it seemingly always picks the lowest free channel, while servo channels start at 6. The old code would presumably work if you added 6 motors before initializing a single servo, but the test robot I've been using has only 4.

`ledcAttachChannel()` lets us choose a channel manually, bypassing this.